### PR TITLE
AMP-52 Add link About The Economist

### DIFF
--- a/src/app/components/article/article-about-economist-link.js
+++ b/src/app/components/article/article-about-economist-link.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'react-emotion';
+import color from '../../styles/color';
+import fontFamily from '../../styles/font-family';
+import text from '../../styles/typography';
+import spacings from '../../styles/spacings';
+
+const StyledLink = styled('a')`
+  display: inline-block;
+  width: 158px;
+  border-radius: 100px;
+  border: solid 1px ${color.cardiff};
+  font-family: ${fontFamily.serif};
+  font-size: ${text.sizeStep[-2]};
+  font-weight: 300;
+  padding: ${spacings.xs};
+  box-sizing: border-box;
+  text-align: center;
+  text-decoration: none;
+  color: ${color.kiev};
+  transition: 0.2s opacity;
+  margin-bottom: ${spacings.m};
+  &:hover {
+    color: ${color.chicago};
+  }
+`;
+
+const ArticleAboutEconomistLink = () => (
+  <StyledLink href="https://www.economist.com/about-the-economist">
+    About <em>The Economist</em>
+  </StyledLink>
+);
+
+export default ArticleAboutEconomistLink;

--- a/src/app/components/article/article.js
+++ b/src/app/components/article/article.js
@@ -6,6 +6,7 @@ import ArticleDescription from './article-description';
 import ArticleMainImage from './article-main-image';
 import StyledArticlePublicationDetails from './article-publication-details';
 import buildComponents from './article-text-builder';
+import ArticleAboutEconomistLink from './article-about-economist-link';
 import spacings from '../../styles/spacings';
 import fontFamily from '../../styles/font-family';
 import typography from '../../styles/typography';
@@ -77,6 +78,7 @@ const Article = ({
         commentsUri={url.comment}
       />
     </StyledBottomPanel>
+    <ArticleAboutEconomistLink />
   </StyledArticleContainer>
 );
 


### PR DESCRIPTION
Added About The Economist link to article.
We agreed to add simple link to page, i've tried to reproduce original styling of it. I did not include logo, because we do not have it in svg form.
prod:
<img width="372" alt="screen shot 2018-05-24 at 15 15 00" src="https://user-images.githubusercontent.com/938947/40491219-66e61cc4-5f65-11e8-9a7e-20c15fd3cf96.png">
amp:
<img width="366" alt="screen shot 2018-05-24 at 15 14 51" src="https://user-images.githubusercontent.com/938947/40491231-6bad0a92-5f65-11e8-9515-0969d14c1c07.png">
